### PR TITLE
Propagate handle from entrypoints to routes

### DIFF
--- a/src/routes/create-entry-point-route.ts
+++ b/src/routes/create-entry-point-route.ts
@@ -20,6 +20,7 @@ import EntryPointRoute from "./EntryPointRoute";
 type EntryPointRouteProperties = {
   loader: LoaderFunction;
   Component: ComponentType<Record<string, never>>;
+  handle?: unknown;
 };
 
 export function createEntryPointRoute<
@@ -30,7 +31,7 @@ export function createEntryPointRoute<
     | SimpleEntryPoint<Component, PreloaderContext>
     | JSResourceReference<SimpleEntryPoint<Component, PreloaderContext>>,
   environmentProvider: IEnvironmentProvider<never>,
-  contextProvider?: PreloaderContextProvider<PreloaderContext>,
+  contextProvider?: PreloaderContextProvider<PreloaderContext>
 ): EntryPointRouteProperties {
   async function loader(args: LoaderFunctionArgs): Promise<any> {
     const loadedEntryPoint =
@@ -67,10 +68,10 @@ export function createEntryPointRoute<
               parameters,
               variables,
               options ?? undefined,
-              environmentProviderOptions ?? undefined,
+              environmentProviderOptions ?? undefined
             ),
-          ],
-        ),
+          ]
+        )
       );
     }
 
@@ -83,5 +84,7 @@ export function createEntryPointRoute<
   return {
     loader,
     Component: EntryPointRoute(entryPoint),
+    // Entrypoints that are JSResourceReferences cannot have a handle.
+    handle: "load" in entryPoint ? undefined : entryPoint.handle,
   };
 }

--- a/src/routes/entry-point-route-object.types.ts
+++ b/src/routes/entry-point-route-object.types.ts
@@ -9,6 +9,8 @@ import type { EntryPointParams } from "./entry-point.types";
 type BadEntryPointType = {
   readonly root: JSResourceReference<EntryPointComponent<any, any, any, any>>;
   readonly getPreloadProps: (entryPointParams: EntryPointParams<any>) => any;
+  // Handle will be propagated to the route if the entrypoint is referenced directly.
+  readonly handle?: unknown;
 };
 
 export interface EntryPointIndexRouteObject

--- a/src/routes/entry-point.types.ts
+++ b/src/routes/entry-point.types.ts
@@ -17,10 +17,14 @@ export interface EntryPointParams<PreloaderContext> extends LoaderFunctionArgs {
   preloaderContext: PreloaderContext;
 }
 
-export type SimpleEntryPoint<
+export interface SimpleEntryPoint<
   Component = BaseEntryPointComponent,
   PreloaderContext = undefined,
-> = EntryPoint<Component, EntryPointParams<PreloaderContext>>;
+> extends EntryPoint<Component, EntryPointParams<PreloaderContext>> {
+  // If you define a handle on your entrypoint we will propagate it to the
+  // corresponding route.
+  handle?: unknown;
+}
 
 export type SimpleEntryPointProps<
   Queries extends Record<string, OperationType>,


### PR DESCRIPTION
This'll let us move our handle definitions to the entrypoints themselves.