### PR TITLE
Make preload hooks more dynamic

### DIFF
--- a/src/Link.tsx
+++ b/src/Link.tsx
@@ -22,41 +22,41 @@ export default function Link({
   onMouseDown,
   ...props
 }: Props) {
-  const fetchEntryPoint = useLinkEntryPointLoadHandler(props.to);
-  const fetchResources = useLinkResourceLoadHandler(props.to);
+  const fetchEntryPoint = useLinkEntryPointLoadHandler();
+  const fetchResources = useLinkResourceLoadHandler();
   const fetchData = useLinkDataLoadHandler(props.to);
 
   useEffect(() => {
     if ("requestIdleCallback" in window) {
-      const id = requestIdleCallback(fetchEntryPoint);
+      const id = requestIdleCallback(() => fetchEntryPoint(props.to));
       return () => cancelIdleCallback(id);
     } else {
-      const id = requestAnimationFrame(fetchEntryPoint);
+      const id = requestAnimationFrame(() => fetchEntryPoint(props.to));
       return () => cancelAnimationFrame(id);
     }
-  }, [fetchEntryPoint]);
+  }, [fetchEntryPoint, props.to]);
 
   const handleMouseEnter = useCallback(
     (e: MouseEvent<HTMLAnchorElement>) => {
-      fetchResources();
+      fetchResources(props.to);
       onMouseEnter?.(e);
     },
-    [onMouseEnter, fetchResources],
+    [onMouseEnter, fetchResources, props.to]
   );
   const handleFocus = useCallback(
     (e: FocusEvent<HTMLAnchorElement>) => {
-      fetchResources();
+      fetchResources(props.to);
       onFocus?.(e);
     },
-    [onFocus, fetchResources],
+    [onFocus, fetchResources, props.to]
   );
   const handleMouseDown = useCallback(
     (e: MouseEvent<HTMLAnchorElement>) => {
-      fetchResources();
+      fetchResources(props.to);
       fetchData();
       onMouseDown?.(e);
     },
-    [onMouseDown, fetchResources, fetchData],
+    [onMouseDown, fetchResources, fetchData, props.to]
   );
 
   return (

--- a/src/useLinkEntryPointLoadHandler.ts
+++ b/src/useLinkEntryPointLoadHandler.ts
@@ -4,7 +4,11 @@ import {
   isValidElement,
   type ComponentType,
 } from "react";
-import { type To, UNSAFE_DataRouterContext, matchRoutes } from "react-router-dom";
+import {
+  type To,
+  UNSAFE_DataRouterContext,
+  matchRoutes,
+} from "react-router-dom";
 import { InternalPreload } from "./routes/internal-preload-symbol";
 import type { PreloadableComponent } from "./routes/EntryPointRoute";
 
@@ -13,53 +17,70 @@ import type { PreloadableComponent } from "./routes/EntryPointRoute";
  * by Link to preload entrypoints on render. You
  * can use this to build your own Link component if necessary.
  */
-export function useLinkEntryPointLoadHandler(to: To): () => void {
+export function useLinkEntryPointLoadHandler(): (to: To) => void;
+/** @deprecated move the `to` argument to the callback */
+export function useLinkEntryPointLoadHandler(to: To): () => void;
+export function useLinkEntryPointLoadHandler(
+  deprecatedTo?: To
+): (to?: To) => void {
   const routes = useContext(UNSAFE_DataRouterContext)?.router.routes ?? [];
 
   // Fetch the entrypoint
-  const fetchEntrypoint = useCallback(() => {
-    const matches = matchRoutes([...routes], to);
-    if (!matches) {
-      return;
-    }
-    for (const match of matches) {
-      const route: any = match.route;
-      const { Component, element } = route;
-      let maybePreloadableComponent:
-        | ComponentType
-        | PreloadableComponent
-        | undefined;
-      if (Component) {
-        maybePreloadableComponent = Component;
-      } else if (isValidElement(element) && typeof element.type !== "string") {
-        maybePreloadableComponent = element.type;
+  const fetchEntrypoint = useCallback(
+    (to: To | undefined) => {
+      to ??= deprecatedTo;
+      // This shouldn't happen, at least one of to or deprecatedTo should be
+      // defined.
+      if (to == null) {
+        return;
       }
+      const matches = matchRoutes([...routes], to);
+      if (!matches) {
+        return;
+      }
+      for (const match of matches) {
+        const route: any = match.route;
+        const { Component, element } = route;
+        let maybePreloadableComponent:
+          | ComponentType
+          | PreloadableComponent
+          | undefined;
+        if (Component) {
+          maybePreloadableComponent = Component;
+        } else if (
+          isValidElement(element) &&
+          typeof element.type !== "string"
+        ) {
+          maybePreloadableComponent = element.type;
+        }
 
-      if (maybePreloadableComponent) {
-        try {
-          if (InternalPreload in maybePreloadableComponent) {
-            maybePreloadableComponent[InternalPreload]?.entryPoint().catch(
-              (e: unknown) => {
-                console.warn(
-                  `[react-router-relay] failed to preload ${
-                    match.pathname
-                  } entrypoint for route ${JSON.stringify(to)}`,
-                  e,
-                );
-              },
+        if (maybePreloadableComponent) {
+          try {
+            if (InternalPreload in maybePreloadableComponent) {
+              maybePreloadableComponent[InternalPreload]?.entryPoint().catch(
+                (e: unknown) => {
+                  console.warn(
+                    `[react-router-relay] failed to preload ${
+                      match.pathname
+                    } entrypoint for route ${JSON.stringify(to)}`,
+                    e
+                  );
+                }
+              );
+            }
+          } catch (e: unknown) {
+            console.warn(
+              `[react-router-relay] failed to call entrypoint preloader ${
+                match.pathname
+              } for route ${JSON.stringify(to)}`,
+              e
             );
           }
-        } catch (e: unknown) {
-          console.warn(
-            `[react-router-relay] failed to call entrypoint preloader ${
-              match.pathname
-            } for route ${JSON.stringify(to)}`,
-            e,
-          );
         }
       }
-    }
-  }, [routes, to]);
+    },
+    [routes, deprecatedTo]
+  );
 
   return fetchEntrypoint;
 }

--- a/src/useLinkResourceLoadHandler.ts
+++ b/src/useLinkResourceLoadHandler.ts
@@ -4,7 +4,11 @@ import {
   isValidElement,
   type ComponentType,
 } from "react";
-import { type To, UNSAFE_DataRouterContext, matchRoutes } from "react-router-dom";
+import {
+  type To,
+  UNSAFE_DataRouterContext,
+  matchRoutes,
+} from "react-router-dom";
 import { InternalPreload } from "./routes/internal-preload-symbol";
 import type { PreloadableComponent } from "./routes/EntryPointRoute";
 
@@ -13,53 +17,71 @@ import type { PreloadableComponent } from "./routes/EntryPointRoute";
  * by Link to preload JSResources for entrypoints on hover or focus events. You
  * can use this to build your own Link component if necessary.
  */
-export function useLinkResourceLoadHandler(to: To): () => void {
+export function useLinkResourceLoadHandler(): (to: To) => void;
+/** @deprecated move the `to` argument to the callback */
+export function useLinkResourceLoadHandler(to: To): () => void;
+export function useLinkResourceLoadHandler(
+  deprecatedTo?: To
+): (to?: To) => void {
   const routes = useContext(UNSAFE_DataRouterContext)?.router.routes ?? [];
 
   // Fetch the static JS resources of any entrypoints
-  const fetchResources = useCallback(() => {
-    const matches = matchRoutes([...routes], to);
-    if (!matches) {
-      return;
-    }
-    for (const match of matches) {
-      const route: any = match.route;
-      const { Component, element } = route;
-      let maybePreloadableComponent:
-        | ComponentType
-        | PreloadableComponent
-        | undefined;
-      if (Component) {
-        maybePreloadableComponent = Component;
-      } else if (isValidElement(element) && typeof element.type !== "string") {
-        maybePreloadableComponent = element.type;
+  const fetchResources = useCallback(
+    (to: To | undefined) => {
+      to ??= deprecatedTo;
+      // This shouldn't happen, at least one of to or deprecatedTo should be
+      // defined.
+      if (to == null) {
+        return;
       }
 
-      if (maybePreloadableComponent) {
-        try {
-          if (InternalPreload in maybePreloadableComponent) {
-            maybePreloadableComponent[InternalPreload]?.resource().catch(
-              (e: unknown) => {
-                console.warn(
-                  `[react-router-relay] failed to preload ${
-                    match.pathname
-                  } resource for route ${JSON.stringify(to)}`,
-                  e,
-                );
-              },
+      const matches = matchRoutes([...routes], to);
+      if (!matches) {
+        return;
+      }
+      for (const match of matches) {
+        const route: any = match.route;
+        const { Component, element } = route;
+        let maybePreloadableComponent:
+          | ComponentType
+          | PreloadableComponent
+          | undefined;
+        if (Component) {
+          maybePreloadableComponent = Component;
+        } else if (
+          isValidElement(element) &&
+          typeof element.type !== "string"
+        ) {
+          maybePreloadableComponent = element.type;
+        }
+
+        if (maybePreloadableComponent) {
+          try {
+            if (InternalPreload in maybePreloadableComponent) {
+              maybePreloadableComponent[InternalPreload]?.resource().catch(
+                (e: unknown) => {
+                  console.warn(
+                    `[react-router-relay] failed to preload ${
+                      match.pathname
+                    } resource for route ${JSON.stringify(to)}`,
+                    e
+                  );
+                }
+              );
+            }
+          } catch (e: unknown) {
+            console.warn(
+              `[react-router-relay] failed to call resource preloader ${
+                match.pathname
+              } for route ${JSON.stringify(to)}`,
+              e
             );
           }
-        } catch (e: unknown) {
-          console.warn(
-            `[react-router-relay] failed to call resource preloader ${
-              match.pathname
-            } for route ${JSON.stringify(to)}`,
-            e,
-          );
         }
       }
-    }
-  }, [routes, to]);
+    },
+    [routes, deprecatedTo]
+  );
 
   return fetchResources;
 }


### PR DESCRIPTION
Currently you cannot use the resource preload in components that can preload a dynamic number of items, this relaxes that constraint. I haven't worked out how to do similar for the data hook as it depends on react-router's `useResolvedPath`, but this will be enough for our current use-case.