### PR TITLE
Fix released version to match repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loop-payments/react-router-relay",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Relay integration for react-router",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
I screwed up when creating the release manually and re-published's build 2.0.0 as 2.1.0