### PR TITLE
Set npmPublishAccess: public

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,3 +3,5 @@ compressionLevel: mixed
 enableGlobalCache: false
 
 nodeLinker: node-modules
+
+npmPublishAccess: public


### PR DESCRIPTION
Our CI job for publishing still isn't working because it is trying to publish as a private package.